### PR TITLE
Update python version installed by pyenv to miniconda

### DIFF
--- a/python_setup.sh
+++ b/python_setup.sh
@@ -4,5 +4,7 @@ brew install python2 python3
 
 curl https://pyenv.run | bash
 
-pyenv install anaconda3-5.3.1
-pyenv global anaconda3-5.3.1
+VERSION="miniconda3-4.3.30"
+
+pyenv install ${VERSION}
+pyenv global ${VERSION}


### PR DESCRIPTION
use miniconda, not anaconda

python 3.6, not python 3.7

pip still has some issues to work out with python 3.7...